### PR TITLE
refactor: return app members in context's member, get app list by pub…

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,7 @@
     "tabWidth": 2,
     "semi": true,
     "singleQuote": true,
-    "importOrder": ["^@?fastify*", "^@?graasp*", "^[./]"],
+    "importOrder": ["^@?fastify", "^@?graasp", "^[./]"],
     "importOrderSeparation": true,
     "importOrderSortSpecifiers": true
   }

--- a/docs/api.md
+++ b/docs/api.md
@@ -121,8 +121,8 @@ App data are all data the app might save. They have the following structure:
 
 The app context contains additional information which might be interesting for you app such as:
 
-- `members`: a list of all the members having access to this item
-- `children`: all children items contained in the app item
+- `members`: a list of all the members having access to app's parent and the app itself
+- `children`: all folder and app items contained in the parent item
 - and all the item's properties such as `ìd`, `name`, `description`, etc 
 
 ### GET App Action

--- a/docs/api.md
+++ b/docs/api.md
@@ -119,11 +119,11 @@ App data are all data the app might save. They have the following structure:
 <a name="app-context"></a>
 ## App Context
 
-The app context contains additional information which might be interesting for you app such as:
+The app context contains additional information which might be interesting for your app such as:
 
-- `members`: a list of all the members having access to app's parent and the app itself
+- `members`: a list of all the members having access to the app's parent and the app itself
 - `children`: all folder and app items contained in the parent item
-- and all the item's properties such as `ìd`, `name`, `description`, etc 
+- and all the item's properties such as `ìd`, `name`, `description`, etc
 
 ### GET App Action
 

--- a/src/app-data/tasks/get-context-task.ts
+++ b/src/app-data/tasks/get-context-task.ts
@@ -57,7 +57,7 @@ export class GetContextTask extends BaseAppDataTask<Actor, Partial<Item>> {
     if (!canRead) throw new MemberCannotReadItem(this.itemId);
 
     const p1 = this.appDataService.getFoldersAndAppsFromParent(item, handler);
-    const p2 = this.appDataService.getParentItemMembers(item, handler);
+    const p2 = this.appDataService.getItemAndParentMembers(item, handler);
 
     const [foldersAndAppItems, members] = await Promise.all([p1, p2]);
     const parent: Partial<Item> & { children?: Partial<Item>[]; members?: Partial<Member>[] } =

--- a/src/db-service.ts
+++ b/src/db-service.ts
@@ -28,14 +28,17 @@ export class AppService {
   );
 
   /**
-   * Get item's app action.
+   * Get apps by publisher
    * @param itemId Item id
    * @param filter Filter
    * @param transactionHandler Database transaction handler
    */
-  public async getAppsList(transactionHandler: TrxHandler): Promise<readonly App[]> {
+  public async getAppsListFor(
+    publisherId: string,
+    transactionHandler: TrxHandler,
+  ): Promise<readonly App[]> {
     return transactionHandler
-      .query<App>(sql`SELECT ${AppService.allColumns} FROM app`)
+      .query<App>(sql`SELECT ${AppService.allColumns} FROM app WHERE publisher=${publisherId}`)
       .then(({ rows }) => rows);
   }
 

--- a/src/db-service.ts
+++ b/src/db-service.ts
@@ -38,7 +38,7 @@ export class AppService {
     transactionHandler: TrxHandler,
   ): Promise<readonly App[]> {
     return transactionHandler
-      .query<App>(sql`SELECT ${AppService.allColumns} FROM app WHERE publisher=${publisherId}`)
+      .query<App>(sql`SELECT ${AppService.allColumns} FROM app WHERE publisher_id = ${publisherId}`)
       .then(({ rows }) => rows);
   }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -47,7 +47,7 @@ const plugin: FastifyPluginAsync<AppsPluginOptions> = async (fastify, options) =
     jwtExpiration = DEFAULT_JWT_EXPIRATION,
     serviceMethod,
     thumbnailsPrefix,
-    GRAASP_PUBLISHER_ID,
+    publisherId,
   } = options;
 
   if (!thumbnailsPrefix) {
@@ -139,7 +139,7 @@ const plugin: FastifyPluginAsync<AppsPluginOptions> = async (fastify, options) =
 
       // get all apps
       fastify.get('/list', { schema: getMany }, async ({ member }) => {
-        const task = new GetAppListTask(member, aS, GRAASP_PUBLISHER_ID);
+        const task = new GetAppListTask(member, aS, publisherId);
         return await runner.runSingle(task);
       });
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -47,6 +47,7 @@ const plugin: FastifyPluginAsync<AppsPluginOptions> = async (fastify, options) =
     jwtExpiration = DEFAULT_JWT_EXPIRATION,
     serviceMethod,
     thumbnailsPrefix,
+    GRAASP_PUBLISHER_ID,
   } = options;
 
   if (!thumbnailsPrefix) {
@@ -138,7 +139,7 @@ const plugin: FastifyPluginAsync<AppsPluginOptions> = async (fastify, options) =
 
       // get all apps
       fastify.get('/list', { schema: getMany }, async ({ member }) => {
-        const task = new GetAppListTask(member, aS);
+        const task = new GetAppListTask(member, aS, GRAASP_PUBLISHER_ID);
         return await runner.runSingle(task);
       });
 

--- a/src/tasks/get-app-list-task.ts
+++ b/src/tasks/get-app-list-task.ts
@@ -15,11 +15,13 @@ export class GetAppListTask implements Task<Actor, readonly App[]> {
     return GetAppListTask.name;
   }
 
-  constructor(actor: Actor, appService: AppService) {
+  constructor(actor: Actor, appService: AppService, publisherId: string) {
     this.appService = appService;
     this.actor = actor;
+    this.publisherId = publisherId;
   }
 
+  publisherId: string;
   actor: Actor;
   targetId?: string;
   data?: readonly App[];
@@ -37,9 +39,9 @@ export class GetAppListTask implements Task<Actor, readonly App[]> {
   async run(handler: DatabaseTransactionHandler): Promise<void> {
     this.status = 'RUNNING';
 
-    const appData = await this.appService.getAppsList(handler);
+    const apps = await this.appService.getAppsListFor(this.publisherId, handler);
 
     this.status = 'OK';
-    this.result = appData;
+    this.result = apps;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface AppsPluginOptions {
 
   serviceMethod: ServiceMethod;
   thumbnailsPrefix: string;
-  GRAASP_PUBLISHER_ID: string;
+  publisherId: string;
 }
 
 // todo: get from plugin-file, currently the enum is defined as integer

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface AppsPluginOptions {
 
   serviceMethod: ServiceMethod;
   thumbnailsPrefix: string;
+  GRAASP_PUBLISHER_ID: string;
 }
 
 // todo: get from plugin-file, currently the enum is defined as integer

--- a/test/app-settings.test.ts
+++ b/test/app-settings.test.ts
@@ -32,7 +32,7 @@ const defaultOptions: AppsPluginOptions = {
   jwtSecret: MOCK_JWT_SECRET,
   serviceMethod: ServiceMethod.LOCAL,
   thumbnailsPrefix: '/',
-  GRAASP_PUBLISHER_ID,
+  publisherId: GRAASP_PUBLISHER_ID,
 };
 
 const runner = new TaskRunner();

--- a/test/app-settings.test.ts
+++ b/test/app-settings.test.ts
@@ -125,7 +125,6 @@ describe('Apps Settings Tests', () => {
             Authorization: `Bearer ${MOCK_TOKEN}`,
           },
         });
-        console.log('response: ', response);
         expect(response.statusCode).toEqual(StatusCodes.OK);
         expect(response.json()).toEqual(appSettings);
       });

--- a/test/app-settings.test.ts
+++ b/test/app-settings.test.ts
@@ -1,7 +1,7 @@
 import { StatusCodes } from 'http-status-codes';
 import { v4 } from 'uuid';
 
-import { ItemMembershipService, ItemService } from 'graasp';
+import { ItemMembershipService, ItemService, Member } from 'graasp';
 import { ServiceMethod } from 'graasp-plugin-file';
 import { ItemMembershipTaskManager, ItemTaskManager, TaskRunner } from 'graasp-test';
 
@@ -11,6 +11,7 @@ import { buildFileItemData } from '../src/util/utils';
 import build from './app';
 import {
   GRAASP_ACTOR,
+  GRAASP_PUBLISHER_ID,
   ITEM_APP,
   MOCK_JWT_SECRET,
   MOCK_LOGGER,
@@ -31,24 +32,28 @@ const defaultOptions: AppsPluginOptions = {
   jwtSecret: MOCK_JWT_SECRET,
   serviceMethod: ServiceMethod.LOCAL,
   thumbnailsPrefix: '/',
+  GRAASP_PUBLISHER_ID,
 };
 
 const runner = new TaskRunner();
 const itemService = {} as unknown as ItemService;
 const itemMembershipsService = {} as unknown as ItemMembershipService;
-const itemTaskManager = new ItemTaskManager();
 const itemMembershipTaskManager = new ItemMembershipTaskManager();
+const itemTaskManager = new ItemTaskManager();
 jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(() => true);
 
-const buildAppOptions = ({ options = defaultOptions, member = GRAASP_ACTOR } = {}) => ({
-  runner,
-  itemService,
-  itemMembershipsService,
-  itemMembershipTaskManager,
-  itemTaskManager,
-  options,
-  member,
-});
+const buildAppOptions = (args?: { options?: AppsPluginOptions; member?: Member }) => {
+  const { options = defaultOptions, member = GRAASP_ACTOR } = args ?? {};
+  return {
+    runner,
+    itemService,
+    itemMembershipsService,
+    itemMembershipTaskManager,
+    itemTaskManager,
+    options,
+    member,
+  };
+};
 
 const item = { id: v4() };
 
@@ -120,6 +125,7 @@ describe('Apps Settings Tests', () => {
             Authorization: `Bearer ${MOCK_TOKEN}`,
           },
         });
+        console.log('response: ', response);
         expect(response.statusCode).toEqual(StatusCodes.OK);
         expect(response.json()).toEqual(appSettings);
       });

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -29,7 +29,7 @@ const defaultOptions: AppsPluginOptions = {
   jwtSecret: MOCK_JWT_SECRET,
   serviceMethod: ServiceMethod.LOCAL,
   thumbnailsPrefix: '/',
-  GRAASP_PUBLISHER_ID,
+  publisherId: GRAASP_PUBLISHER_ID,
 };
 
 const runner = new TaskRunner();

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,15 +1,16 @@
 import { StatusCodes } from 'http-status-codes';
 import { v4 } from 'uuid';
 
-import { ItemMembershipService, ItemMembershipTaskManager, ItemService } from 'graasp';
+import { ItemMembershipService, ItemService, Member } from 'graasp';
 import { ServiceMethod } from 'graasp-plugin-file';
-import { ItemTaskManager, TaskRunner } from 'graasp-test';
+import { ItemMembershipTaskManager, ItemTaskManager, TaskRunner } from 'graasp-test';
 
 import { AppService } from '../src/db-service';
 import { AppsPluginOptions } from '../src/types';
 import build from './app';
 import {
   GRAASP_ACTOR,
+  GRAASP_PUBLISHER_ID,
   MOCK_APPS,
   MOCK_APP_ORIGIN,
   MOCK_CONTEXT,
@@ -28,24 +29,28 @@ const defaultOptions: AppsPluginOptions = {
   jwtSecret: MOCK_JWT_SECRET,
   serviceMethod: ServiceMethod.LOCAL,
   thumbnailsPrefix: '/',
+  GRAASP_PUBLISHER_ID,
 };
 
 const runner = new TaskRunner();
 const itemService = {} as unknown as ItemService;
 const itemMembershipsService = {} as unknown as ItemMembershipService;
-const itemMembershipTaskManager = {} as unknown as ItemMembershipTaskManager;
+const itemMembershipTaskManager = new ItemMembershipTaskManager();
 const itemTaskManager = new ItemTaskManager();
 jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(() => true);
 
-const buildAppOptions = ({ options = defaultOptions, member = GRAASP_ACTOR } = {}) => ({
-  runner,
-  itemService,
-  itemMembershipsService,
-  itemMembershipTaskManager,
-  itemTaskManager,
-  options,
-  member,
-});
+const buildAppOptions = (args?: { options?: AppsPluginOptions; member?: Member }) => {
+  const { options = defaultOptions, member = GRAASP_ACTOR } = args ?? {};
+  return {
+    runner,
+    itemService,
+    itemMembershipsService,
+    itemMembershipTaskManager,
+    itemTaskManager,
+    options,
+    member,
+  };
+};
 
 describe('Apps Plugin Tests', () => {
   beforeEach(() => {
@@ -100,7 +105,7 @@ describe('Apps Plugin Tests', () => {
         const app = await build(buildAppOptions());
 
         const apps = MOCK_APPS;
-        jest.spyOn(AppService.prototype, 'getAppsList').mockResolvedValue(apps);
+        jest.spyOn(AppService.prototype, 'getAppsListFor').mockResolvedValue(apps);
         mockRunSingle(apps);
 
         const response = await app.inject({

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -13,6 +13,8 @@ export const GRAASP_ACTOR: Actor = {
   id: 'actorid',
 };
 
+export const GRAASP_PUBLISHER_ID = 'publisher-id';
+
 export const MOCK_JWT_SECRET = '1234567890123456789012345678901234567890';
 
 export const MOCK_S3_OPTIONS = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1408,8 +1408,8 @@ __metadata:
 
 "@types/graasp@github:graasp/graasp-types":
   version: 0.1.0
-  resolution: "@types/graasp@https://github.com/graasp/graasp-types.git#commit=c49643d52243f9819678a53cfe46080c17c321ba"
-  checksum: cabc5781ead8f3e9a2a1849b815ac0b4df7795fa871aec9efbc27a3d26119338819533301cccaa51ff87b74eb74a0d2a5595b18e840a6314eaf6698150722843
+  resolution: "@types/graasp@https://github.com/graasp/graasp-types.git#commit=1dde116429496a40a080dbaddf489a9f47196302"
+  checksum: 8ada1dcede2fcd9bd5cf7c5acda81f3a11a291e240b8f4929c7824e2473932c877fa4ce784f3e0cc39cd545db61ded694c2e1ceb3bf870be1e58f32b36b20cbc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR includes:
- close #29 
- Adds to the app context's `members` data the current item's memberships